### PR TITLE
Fixes a number of deprecation issues.

### DIFF
--- a/lib/omni-ruler.coffee
+++ b/lib/omni-ruler.coffee
@@ -1,0 +1,17 @@
+OmniRulerView = require './omni-ruler-view'
+
+module.exports =
+  config:
+    enabled:
+      type: 'boolean'
+      default: true
+    columns:
+      default: []
+      type: 'array'
+      items:
+        type: 'integer'
+
+  activate: ->
+    atom.workspace.observeTextEditors (editor) ->
+      editorElement = atom.views.getView(editor)
+      omniRulerView = new OmniRulerView().initialize(editor, editorElement)

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
   "name": "omni-ruler",
-  "main": "./lib/omni-ruler-view",
+  "main": "./lib/omni-ruler",
   "version": "0.3.1",
   "description": "Add multiple rulers/wrap guides",
   "repository": "https://github.com/Problematic/omni-ruler",
   "license": "MIT",
+  "coffeelintConfig": {
+    "max_line_length": {
+      "name": "max_line_length",
+      "value": 120,
+      "level": "warn",
+      "limitComments": true
+    }
+  },
   "engines": {
-    "atom": "*"
+    "atom": ">=0.194.0 <2.0.0"
   },
   "dependencies": {}
 }

--- a/styles/omni-ruler.less
+++ b/styles/omni-ruler.less
@@ -1,0 +1,12 @@
+@import "syntax-variables";
+
+atom-text-editor::shadow {
+  .omni-ruler {
+    height: 100%;
+    width: 1px;
+    z-index: 100;
+    position: absolute;
+    top: 0;
+    background-color: @syntax-wrap-guide-color;
+  }
+}

--- a/stylesheets/omni-ruler.less
+++ b/stylesheets/omni-ruler.less
@@ -1,7 +1,0 @@
-.wrap-guide {
-  height: 100%;
-  width: 1px;
-  z-index: 100;
-  position: absolute;
-  top: 0;
-}


### PR DESCRIPTION
Also:
- atom.engines "*" -> ">=0.194.0 <2.0.0"
- refactors OmniRulerView to be more like wrap-guide
- get default column width and enable/disable for grammar
