### PR TITLE
Remove shadow DOM styles

### DIFF
--- a/styles/omni-ruler.less
+++ b/styles/omni-ruler.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor::shadow {
+atom-text-editor {
   .omni-ruler {
     height: 100%;
     width: 1px;

--- a/styles/omni-ruler.less
+++ b/styles/omni-ruler.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor {
+atom-text-editor.editor {
   .omni-ruler {
     height: 100%;
     width: 1px;


### PR DESCRIPTION
This patch removes shadow DOM which is got removed from text editors since Atom 1.13. It should fix #14.
