### PR TITLE
Update omni-ruler.less

### DIFF
--- a/styles/omni-ruler.less
+++ b/styles/omni-ruler.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .omni-ruler {
     height: 100%;
     width: 1px;


### PR DESCRIPTION
closes #14

```
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

atom-text-editor::shadow .omni-ruler => atom-text-editor.editor .omni-ruler
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
```