### PR TITLE
Fix HTMLElement.rootElement is deprecated. (Atom 1.1.9.0) #17

### DIFF
--- a/lib/omni-ruler-view.coffee
+++ b/lib/omni-ruler-view.coffee
@@ -9,7 +9,7 @@ class OmniRulerView extends HTMLDivElement
     this
 
   attachToLines: ->
-    lines = @editorElement.rootElement?.querySelector?('.lines')
+    lines = @editorElement?.querySelector?('.lines')
     lines?.appendChild(this)
 
   handleEvents: ->


### PR DESCRIPTION
Fixing issue #17 